### PR TITLE
Correct scheme configuration key handling

### DIFF
--- a/src/OssServiceProvider.php
+++ b/src/OssServiceProvider.php
@@ -92,6 +92,7 @@ class OssServiceProvider extends ServiceProvider
             if (isset($config['schema']) && ! isset($config['scheme'])) {
                 $config['scheme'] = $config['schema'];
             }
+
             if (isset($config['scheme'])) {
                 $ossClient->setUseSSL($config['scheme'] === 'https');
             }

--- a/src/OssServiceProvider.php
+++ b/src/OssServiceProvider.php
@@ -88,8 +88,12 @@ class OssServiceProvider extends ServiceProvider
                 $ossClient->setConnectTimeout($config['http']['connect_timeout']);
             }
 
-            if (isset($config['schema'])) {
-                $ossClient->setUseSSL($config['schema'] === 'https');
+            // Fix typo, will be removed in the next major version.
+            if (isset($config['schema']) && ! isset($config['scheme'])) {
+                $config['scheme'] = $config['schema'];
+            }
+            if (isset($config['scheme'])) {
+                $ossClient->setUseSSL($config['scheme'] === 'https');
             }
 
             $ossAdapter = new Adapter(


### PR DESCRIPTION
Fix typo in configuration key from 'schema' to 'scheme' for scheme settings.